### PR TITLE
Ensure highlight animation connects once

### DIFF
--- a/app/ui/components/timeline.py
+++ b/app/ui/components/timeline.py
@@ -40,6 +40,10 @@ class TimelineWidget(QWidget):
         self.highlight_animation = QPropertyAnimation(self, b"highlight_scale")
         self.highlight_animation.setDuration(150)
         self.highlight_animation.setEasingCurve(QEasingCurve.OutBack)
+        if not self.highlight_animation.finished.isSignalConnected(
+            self.reset_highlight_scale
+        ):
+            self.highlight_animation.finished.connect(self.reset_highlight_scale)
 
         # Colors
         self.bg_color = QColor(240, 240, 245)
@@ -72,7 +76,6 @@ class TimelineWidget(QWidget):
         # Scale animation
         self.highlight_animation.setStartValue(1.0)
         self.highlight_animation.setEndValue(1.15)
-        self.highlight_animation.finished.connect(self.reset_highlight_scale)
         self.highlight_animation.start()
 
     def reset_highlight_scale(self):


### PR DESCRIPTION
## Summary
- Connect highlight animation's finished signal in `__init__` and guard against duplicates
- Avoid reconnecting during each step hit

## Testing
- `ruff check app/ui/components/timeline.py`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68be80187a04832ab0a85fe5a73dfe58