### PR TITLE
feat: show song info beside progression button

### DIFF
--- a/app/ui/components/progression_controls.py
+++ b/app/ui/components/progression_controls.py
@@ -1,6 +1,6 @@
 """Chord progression controls widget."""
 
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QLabel
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QPushButton, QLabel
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont
 
@@ -17,21 +17,23 @@ class ProgressionControlsWidget(QWidget):
 
     def init_ui(self):
         """Initialize the progression controls UI."""
-        layout = QVBoxLayout(self)
+        layout = QHBoxLayout(self)
         layout.setContentsMargins(10, 10, 10, 10)
-        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.setAlignment(Qt.AlignmentFlag.AlignVCenter)
 
-        # Song name display (centered)
+        # Song name display (left of button)
         self.song_name_label = QLabel("Песня не выбрана")
         self.song_name_label.setFont(QFont("Arial", 12, QFont.Weight.Bold))
-        self.song_name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        
-        # Next progression button (below label)
+        self.song_name_label.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        self.song_name_label.setWordWrap(True)
+
+        # Next progression button
         self.next_button = QPushButton("Следующая прогрессия ▶")
         self.next_button.clicked.connect(self.next_progression_clicked.emit)
         self.next_button.setEnabled(False)
 
-        layout.addStretch(1)
         layout.addWidget(self.song_name_label)
         layout.addWidget(self.next_button)
         layout.addStretch(1)
@@ -40,7 +42,7 @@ class ProgressionControlsWidget(QWidget):
         """Set the current song and update display."""
         self.current_song = song
         if song:
-            self.song_name_label.setText(f"{song.artist} - {song.title}")
+            self.song_name_label.setText(f"{song.title}\n{song.artist}")
             # Enable button only if there are multiple progressions/sections
             self.next_button.setEnabled(song.has_extended_structure())
         else:


### PR DESCRIPTION
## Summary
- Reworked progression controls layout so song info sits to the left of the "Следующая прогрессия" button
- Display song title and artist on separate lines within the controls

## Testing
- `python -m black --check app/ui/components/progression_controls.py`
- `ruff check app/ui/components/progression_controls.py`
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file; ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_b_68bee1434478832a91d7cc7ec9b89428