### PR TITLE
Use section chords in song view

### DIFF
--- a/app/ui/components/chord_display.py
+++ b/app/ui/components/chord_display.py
@@ -1,16 +1,16 @@
 """Enhanced chord display widget with fretboard diagrams."""
 
-from PySide6.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QFont, QPainter, QPen, QBrush, QColor
-from typing import Optional, List
+from typing import List
 
 from app.core.chord_library import get_chord_diagram, chord_difficulty_color
 
 
 class ChordWidget(QWidget):
     """Widget displaying a single chord with name and fretboard diagram."""
-    
+
     def __init__(self, chord_name: str):
         super().__init__()
         self.chord_name = chord_name
@@ -18,27 +18,29 @@ class ChordWidget(QWidget):
         self.is_highlighted = False
         self.setMinimumSize(100, 140)
         self.setMaximumSize(140, 180)
-        
+
     def paintEvent(self, event):
         """Paint the chord widget with name and diagram."""
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-        
+
         # Background
         bg_color = QColor("#4CAF50") if self.is_highlighted else QColor("#f0f0f0")
         border_color = QColor("#45a049") if self.is_highlighted else QColor("#ddd")
         text_color = QColor("white") if self.is_highlighted else QColor("#333")
-        
+
         painter.setBrush(QBrush(bg_color))
         painter.setPen(QPen(border_color, 2))
-        painter.drawRoundedRect(2, 2, self.width()-4, self.height()-4, 8, 8)
-        
+        painter.drawRoundedRect(2, 2, self.width() - 4, self.height() - 4, 8, 8)
+
         # Chord name
         painter.setFont(QFont("Arial", 14, QFont.Weight.Bold))
         painter.setPen(QPen(text_color))
-        name_rect = painter.boundingRect(0, 5, self.width(), 25, Qt.AlignmentFlag.AlignCenter, self.chord_name)
+        name_rect = painter.boundingRect(
+            0, 5, self.width(), 25, Qt.AlignmentFlag.AlignCenter, self.chord_name
+        )
         painter.drawText(name_rect, Qt.AlignmentFlag.AlignCenter, self.chord_name)
-        
+
         # Difficulty indicator
         if self.chord_diagram:
             difficulty_color = chord_difficulty_color(self.chord_diagram.difficulty)
@@ -46,33 +48,43 @@ class ChordWidget(QWidget):
             painter.setPen(QPen(QColor(difficulty_color)))
             dot_size = 8
             painter.drawEllipse(self.width() - 15, 8, dot_size, dot_size)
-            
+
             # Mini fretboard diagram
-            self._draw_mini_fretboard(painter, 10, 35, self.width()-20, self.height()-50)
+            self._draw_mini_fretboard(
+                painter, 10, 35, self.width() - 20, self.height() - 50
+            )
         else:
             # No diagram available
             painter.setPen(QPen(QColor("#999")))
             painter.setFont(QFont("Arial", 9))
-            painter.drawText(10, 35, self.width()-20, self.height()-50, 
-                           Qt.AlignmentFlag.AlignCenter, "Аппликатура\nне найдена")
-    
-    def _draw_mini_fretboard(self, painter: QPainter, x: int, y: int, width: int, height: int):
+            painter.drawText(
+                10,
+                35,
+                self.width() - 20,
+                self.height() - 50,
+                Qt.AlignmentFlag.AlignCenter,
+                "Аппликатура\nне найдена",
+            )
+
+    def _draw_mini_fretboard(
+        self, painter: QPainter, x: int, y: int, width: int, height: int
+    ):
         """Draw a mini fretboard diagram."""
         if not self.chord_diagram:
             return
-            
+
         num_strings = 6
         num_frets = 4
-        
+
         string_spacing = width / (num_strings - 1)
         fret_spacing = height / (num_frets + 1)
-        
+
         # Draw strings (vertical lines)
         painter.setPen(QPen(QColor("#C0C0C0"), 1))
         for i in range(num_strings):
             string_x = x + i * string_spacing
             painter.drawLine(int(string_x), y, int(string_x), y + height)
-        
+
         # Draw frets (horizontal lines)
         painter.setPen(QPen(QColor("#666"), 1))
         for i in range(num_frets + 1):
@@ -80,11 +92,11 @@ class ChordWidget(QWidget):
             line_width = 2 if i == 0 else 1  # Thicker nut
             painter.setPen(QPen(QColor("#666"), line_width))
             painter.drawLine(x, int(fret_y), x + width, int(fret_y))
-        
+
         # Draw finger positions
         for string_idx, fret in enumerate(self.chord_diagram.frets):
             string_x = x + string_idx * string_spacing
-            
+
             if fret == -1:  # Muted string
                 painter.setPen(QPen(QColor("#e74c3c"), 2))
                 painter.drawLine(int(string_x - 3), y - 8, int(string_x + 3), y - 2)
@@ -98,7 +110,7 @@ class ChordWidget(QWidget):
                 painter.setBrush(QBrush(QColor("#3498db")))
                 painter.setPen(QPen(QColor("#3498db")))
                 painter.drawEllipse(int(string_x - 4), int(fret_y - 4), 8, 8)
-    
+
     def set_highlighted(self, highlighted: bool):
         """Set highlight state and update display."""
         self.is_highlighted = highlighted
@@ -121,17 +133,17 @@ class ChordDisplayWidget(QWidget):
         layout.setContentsMargins(20, 15, 20, 15)
         layout.setSpacing(15)
         self.chord_layout = layout
-        
+
         # Center the chords in the widget
         layout.addStretch()
-        
+
         # Placeholder label
         self.no_chords_label = QLabel("Аккорды не загружены")
         self.no_chords_label.setFont(QFont("Arial", 14))
         self.no_chords_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.no_chords_label.setStyleSheet("color: #666; font-style: italic;")
         layout.addWidget(self.no_chords_label)
-        
+
         layout.addStretch()
 
     def set_song(self, song):
@@ -148,27 +160,30 @@ class ChordDisplayWidget(QWidget):
         """Update the chord display based on current song and section."""
         # Clear existing chord labels
         self.clear_chords()
-        
+
         if not self.current_song:
             self.show_no_chords("Песня не выбрана")
             return
-        
+
         # Get chords from current section or song
-        chords = []
-        if self.current_section and hasattr(self.current_section, 'progression'):
-            chords = self.current_section.progression
-        elif hasattr(self.current_song, 'progression') and self.current_song.progression:
+        chords: List[str] = []
+        if self.current_section:
+            if hasattr(self.current_section, "chords"):
+                chords = self.current_section.chords
+            elif hasattr(self.current_section, "progression"):
+                chords = self.current_section.progression
+        elif getattr(self.current_song, "progression", []):
             chords = self.current_song.progression
-        elif hasattr(self.current_song, 'all_chords') and self.current_song.all_chords:
+        elif getattr(self.current_song, "all_chords", []):
             chords = self.current_song.all_chords[:4]  # Show first 4 chords
-        
+
         if not chords:
             self.show_no_chords("Аккорды не указаны")
             return
-        
+
         # Hide no chords label
         self.no_chords_label.hide()
-        
+
         # Create chord widgets with diagrams
         for i, chord in enumerate(chords):
             chord_widget = ChordWidget(chord)

--- a/app/ui/song_view.py
+++ b/app/ui/song_view.py
@@ -5,7 +5,6 @@ from PySide6.QtWidgets import (
     QPushButton,
     QLabel,
     QGroupBox,
-    QTextEdit,
     QSplitter,
     QCheckBox,
     QComboBox,
@@ -53,7 +52,7 @@ class SongView(QWidget):
         header_layout.addWidget(self.back_button)
 
         header_layout.addStretch()
-        
+
         # Song selector
         header_layout.addWidget(QLabel("Песня:"))
         self.song_combo = QComboBox()
@@ -89,7 +88,7 @@ class SongView(QWidget):
 
         structure_layout.addLayout(section_layout)
 
-        # Chord progression section with two panes
+        # Chord section with two panes
         chord_section_layout = QHBoxLayout()
 
         # Left pane: progression controls
@@ -101,7 +100,7 @@ class SongView(QWidget):
         chord_section_layout.addWidget(progression_group)
 
         # Right pane: chord display
-        chords_group = QGroupBox("Прогрессия аккордов")
+        chords_group = QGroupBox("Аккорды")
         chords_group_layout = QVBoxLayout(chords_group)
         self.chord_display = ChordDisplayWidget()
         chords_group_layout.addWidget(self.chord_display)
@@ -172,7 +171,7 @@ class SongView(QWidget):
 
         # Set splitter proportions (rhythm visualization gets most space like in practice view)
         splitter.setStretchFactor(0, 1)  # Structure
-        splitter.setStretchFactor(1, 3)  # Rhythm visualization gets 3x more space 
+        splitter.setStretchFactor(1, 3)  # Rhythm visualization gets 3x more space
         splitter.setStretchFactor(2, 1)  # Transport controls
 
         layout.addWidget(splitter)
@@ -349,21 +348,21 @@ class SongView(QWidget):
     def set_patterns(self, patterns):
         """Set available patterns."""
         self.patterns = patterns
-        
+
     def set_songs(self, songs):
         """Set available songs."""
         self.songs = songs
         self.populate_song_combo()
-        
+
     def populate_song_combo(self):
         """Populate the song selection combo box."""
         self.song_combo.clear()
         self.song_combo.addItem("Выберите песню...", None)
-        
+
         for song in self.songs:
             display_name = f"{song.artist} - {song.title}"
             self.song_combo.addItem(display_name, song)
-            
+
     def on_song_changed(self, song_text: str):
         """Handle song selection change."""
         song = self.song_combo.currentData()
@@ -374,10 +373,10 @@ class SongView(QWidget):
         """Show the song information popup dialog."""
         if not self.current_song:
             return
-            
+
         if not self.song_info_popup:
             self.song_info_popup = SongInfoPopup(self)
-            
+
         self.song_info_popup.set_song(self.current_song)
         self.song_info_popup.exec()
 
@@ -480,21 +479,21 @@ class SongView(QWidget):
                 ):
                     # Auto-advance to next section
                     self.next_section()
-                    
+
     def _update_chord_highlighting(self, step_index: int):
         """Update chord highlighting based on current step."""
         if not self.current_section:
             return
-            
+
         # Get pattern to calculate bars
         pattern = self.patterns.get(self.current_section.pattern)
         if not pattern:
             return
-            
+
         # Calculate current bar and chord index
         steps_per_bar = pattern.steps_per_bar
         current_bar = (step_index // steps_per_bar) % len(self.current_section.chords)
-        
+
         # Highlight current chord
         self.chord_display.highlight_chord(current_bar)
 


### PR DESCRIPTION
## Summary
- label song view chords pane as "Аккорды"
- display chords from the current song section
- tidy unused imports after lint

## Testing
- `ruff check app/ui/song_view.py app/ui/components/chord_display.py`
- `pytest` *(fails: ModuleNotFoundError / missing libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_b_68bfde672f20832a8d664f06e3b25aae