### PR TITLE
Add chord synthesis for song mode

### DIFF
--- a/app/core/chord_synth.py
+++ b/app/core/chord_synth.py
@@ -1,0 +1,85 @@
+"""Simple chord synthesizer for guitar and piano sounds."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .chord_library import get_chord_diagram
+
+# Standard tuning for guitar (E2, A2, D3, G3, B3, E4)
+STANDARD_TUNING = [82.41, 110.0, 146.83, 196.0, 246.94, 329.63]
+
+
+def _frequencies_from_chord(chord_name: str) -> list[float]:
+    """Get frequencies for all strings in a chord diagram."""
+    diagram = get_chord_diagram(chord_name)
+    if diagram is None:
+        raise ValueError(f"Unknown chord: {chord_name}")
+    freqs: list[float] = []
+    for base, fret in zip(STANDARD_TUNING, diagram.frets):
+        if fret < 0:
+            continue  # muted string
+        freqs.append(base * (2 ** (fret / 12)))
+    return freqs
+
+
+def generate_chord(
+    chord_name: str,
+    instrument: str = "guitar",
+    direction: str = "D",
+    duration: float = 1.0,
+    sample_rate: int = 44100,
+) -> np.ndarray:
+    """Generate a chord waveform.
+
+    Parameters
+    ----------
+    chord_name:
+        Name of the chord (e.g., "Am", "C").
+    instrument:
+        Either ``"guitar"`` or ``"piano"``.
+    direction:
+        Strum direction, ``"D"`` or ``"U"``. Used for guitar to stagger note
+        start times.
+    duration:
+        Duration of generated sound in seconds.
+    sample_rate:
+        Sampling rate of the generated waveform.
+    """
+
+    freqs = _frequencies_from_chord(chord_name)
+    if not freqs:
+        return np.zeros(int(sample_rate * duration), dtype=np.float32)
+
+    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    output = np.zeros_like(t)
+
+    if instrument == "piano":
+        envelope = np.exp(-3 * t)
+        for f in freqs:
+            wave = (
+                np.sin(2 * np.pi * f * t) + 0.5 * np.sin(2 * np.pi * 2 * f * t)
+            ) * envelope
+            output[: wave.size] += wave
+    else:  # guitar
+        strum_delay = 0.01  # seconds between strings
+        indices = list(range(len(freqs)))
+        if direction.upper() == "U":
+            indices = list(reversed(indices))
+        for i, idx in enumerate(indices):
+            f = freqs[idx]
+            delay_samples = int(i * strum_delay * sample_rate)
+            segment = t[: t.size - delay_samples]
+            env = np.exp(-5 * segment)
+            wave = np.sin(2 * np.pi * f * segment) * env
+            output[delay_samples : delay_samples + wave.size] += wave
+
+    # Normalize amplitude
+    max_val = np.max(np.abs(output))
+    if max_val > 0:
+        output = output / (max_val * len(freqs))
+
+    return output.astype(np.float32)
+
+
+__all__ = ["generate_chord"]

--- a/app/ui/practice_view.py
+++ b/app/ui/practice_view.py
@@ -5,7 +5,6 @@ from PySide6.QtWidgets import (
     QPushButton,
     QLabel,
     QGroupBox,
-    QTextEdit,
     QSplitter,
     QCheckBox,
 )
@@ -473,7 +472,14 @@ class PracticeView(QWidget):
 
             # Play strum sound
             if step.dir != "-":
-                self.audio.play_strum(step.dir, step.accent)
+                current_chord = (
+                    self.current_progression[self.current_chord_index]
+                    if self.current_progression
+                    else None
+                )
+                self.audio.play_strum(
+                    step.dir, step.accent, chord=current_chord
+                )
 
             # Play metronome click with beat awareness
             beats_per_bar = self.current_pattern.time_sig[0]

--- a/app/ui/song_view.py
+++ b/app/ui/song_view.py
@@ -539,14 +539,23 @@ class SongView(QWidget):
 
         bar_length = pattern.steps_per_bar
         bar_step = step_index % bar_length
+        current_chord: str | None = None
+        if self.current_section:
+            chord_index = (step_index // bar_length) % len(self.current_section.chords)
+            current_chord = self.current_section.chords[chord_index]
+        elif self.current_song.progression:
+            chord_index = (step_index // bar_length) % len(
+                self.current_song.progression
+            )
+            current_chord = self.current_song.progression[chord_index]
 
         # Play audio feedback
         if bar_step < len(pattern.steps):
             step = pattern.steps[bar_step]
 
-            # Play strum sound
+            # Play strum or chord sound
             if step.dir != "-":
-                self.audio.play_strum(step.dir, step.accent)
+                self.audio.play_strum(step.dir, step.accent, chord=current_chord)
 
             # Play metronome click with beat awareness
             beats_per_bar = pattern.time_sig[0]

--- a/tests/test_chord_synth.py
+++ b/tests/test_chord_synth.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.core.chord_synth import generate_chord
+
+
+def test_generate_chord_guitar():
+    data = generate_chord("Am", instrument="guitar", duration=0.2, sample_rate=8000)
+    assert isinstance(data, np.ndarray)
+    assert data.dtype == np.float32
+    assert data.size == int(0.2 * 8000)
+    assert np.any(data != 0)
+
+
+def test_generate_chord_piano():
+    data = generate_chord("C", instrument="piano", duration=0.2, sample_rate=8000)
+    assert isinstance(data, np.ndarray)
+    assert data.dtype == np.float32
+    assert data.size == int(0.2 * 8000)
+    assert np.any(data != 0)

--- a/tests/test_practice_view_chords.py
+++ b/tests/test_practice_view_chords.py
@@ -1,0 +1,38 @@
+from app.ui.practice_view import PracticeView
+from app.core.patterns import Step, StrumPattern
+
+
+class DummyAudio:
+    def __init__(self):
+        self.calls = []
+
+    def play_strum(self, direction, accent, chord=None):
+        self.calls.append((direction, accent, chord))
+
+    def play_click_high(self):
+        pass
+
+    def play_click(self, accent=False):
+        pass
+
+
+def test_on_practice_tick_uses_current_chord():
+    view = PracticeView.__new__(PracticeView)
+    view.audio = DummyAudio()
+    view.current_progression = ["Am", "E"]
+    view.current_chord_index = 0
+    view.current_pattern = StrumPattern(
+        id="test",
+        name="Test",
+        time_sig=(4, 4),
+        steps_per_bar=4,
+        steps=[Step(0.0, "D", 1.0)],
+        bpm_default=120,
+        bpm_min=60,
+        bpm_max=180,
+        notes="",
+    )
+
+    view.on_practice_tick(0.0, 0)
+
+    assert view.audio.calls == [("D", 1.0, "Am")]


### PR DESCRIPTION
## Summary
- synthesize guitar or piano chords via new `generate_chord` utility
- allow `AudioEngine.play_strum` to render chords and expose `play_chord`
- play song progression chords in SongView instead of generic strum samples
- cover chord synthesis with a dedicated test

## Testing
- `ruff check app/core/audio_engine.py app/core/chord_synth.py app/ui/song_view.py tests/test_chord_synth.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68bfe9490290832a98032fdab1cad843